### PR TITLE
Update freqgen.py

### DIFF
--- a/freqgen/freqgen.py
+++ b/freqgen/freqgen.py
@@ -61,7 +61,7 @@ def amino_acid_seq(length, frequencies):
         raise ValueError("Length must be a positive integer")
 
     sequence = ""
-    amino_acids, frequencies = zip(*frequencies.items())
+    amino_acids, frequencies = zip(*frequencies[list(frequencies.keys())[0]].items())
     for i in range(length):
         sequence += np.random.choice(amino_acids, p=frequencies)
     return sequence


### PR DESCRIPTION
Hi @Benjamin-Lee 

I was trying to use Freqgen to generate a random CDS. I used the example from the [docs](https://freqgen.readthedocs.io/en/latest/usage.html)

```python
>>> length = 8 # the length of the sequence to generate
>>> aa_sequence = amino_acid_seq(length, k_mer_frequencies("ALLQ", 1))
>>> aa_sequence
'ALAAQLQL'
```

I got this error:

```python
aa_sequence = freqgen.amino_acid_seq(length, freqgen.k_mer_frequencies("ALLQ", 1))
File "/usr/local/lib/python3.7/dist-packages/freqgen/freqgen.py", line 62, in amino_acid_seq
    sequence += np.random.choice(amino_acids, p=frequencies)
File "mtrand.pyx", line 1135, in mtrand.RandomState.choice
TypeError: float() argument must be a string or a number, not 'dict'
```

numpy.random.choice(), raises ValueError when p is not 1-dimensional, if a is an array-like of size 0, if p is not a vector of probabilities, if a and p have different lengths.

https://github.com/Lab41/freqgen/blob/e7aca38827107674796236cd5fb42b7a3b5f6556/freqgen/freqgen.py#L66

Here, p = frequencies, and frequencies is a dict. so numpy.random.choice() raises the above error.
Also, amino_acids is equal to (1,).

I tried to solve the error, and it worked for me. 

https://github.com/AliYoussef96/freqgen/blob/758120919851a464471fd6a1f8725452617023ca/freqgen/freqgen.py#L64

Feel free to merge it, or just search for a better solution. 